### PR TITLE
Fix filter

### DIFF
--- a/src/createFilter.js
+++ b/src/createFilter.js
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve, sep } from 'path';
 import { makeRe } from 'minimatch';
 import ensureArray from './utils/ensureArray';
 
@@ -8,6 +8,7 @@ export default function createFilter ( include, exclude ) {
 
 	return function ( id ) {
 		var included = !include.length;
+		id = id.split(sep).join('/');
 
 		include.forEach( pattern => {
 			if ( pattern.test( id ) ) included = true;


### PR DESCRIPTION
This is a decision of test failure on windows in rollup repo. It happened after @eventualbuddha updated rollup-plugin-npm which resolves paths with native separators instead of only direct slash. In this case I highly recommend to enable travis and appveyor in all repos,