### PR TITLE
use Minimatch#match instead of makeRe

### DIFF
--- a/src/createFilter.js
+++ b/src/createFilter.js
@@ -1,21 +1,21 @@
 import { resolve, sep } from 'path';
-import { makeRe } from 'minimatch';
+import { Minimatch } from 'minimatch';
 import ensureArray from './utils/ensureArray';
 
 export default function createFilter ( include, exclude ) {
-	include = ensureArray( include ).map( id => resolve( id ) ).map( makeRe );
-	exclude = ensureArray( exclude ).map( id => resolve( id ) ).map( makeRe );
+	include = ensureArray( include ).map( id => resolve( id ) ).map( id => new Minimatch(id) );
+	exclude = ensureArray( exclude ).map( id => resolve( id ) ).map( id => new Minimatch(id) );
 
 	return function ( id ) {
 		var included = !include.length;
 		id = id.split(sep).join('/');
 
-		include.forEach( pattern => {
-			if ( pattern.test( id ) ) included = true;
+		include.forEach( minimatch => {
+			if ( minimatch.match( id ) ) included = true;
 		});
 
-		exclude.forEach( pattern => {
-			if ( pattern.test( id ) ) included = false;
+		exclude.forEach( minimatch => {
+			if ( minimatch.match( id ) ) included = false;
 		});
 
 		return included;

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,12 @@ describe( 'rollup-pluginutils', function () {
 			assert.ok( filter( path.resolve( 'foo/bar' ) ) );
 			assert.ok( !filter( path.resolve( 'foo/baz' ) ) );
 		});
+
+		it( 'negation patterns', function () {
+			var filter = createFilter([ 'a/!(b)/c' ]);
+			assert.ok( filter( path.resolve( 'a/d/c' ) ) );
+			assert.ok( !filter( path.resolve( 'a/b/c' ) ) );
+		});
 	});
 
 	describe( 'addExtension', function () {


### PR DESCRIPTION
I'm using the babel plugin with exclude option:

```
 babel({ runtimeHelpers: true , exclude: ['node_modules/!(axios)/**'] })
```

However, axios is not transformed.

I did some debugging, and it turns out minimatch has an issue generating the RegExps: https://github.com/isaacs/minimatch/issues/83

This is a quick fix to get it work before the issue got fixed.