### PR TITLE
Chore/refactor ensure array

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "description": "Functionality commonly needed by Rollup plugins",
   "version": "1.5.2",
   "main": "dist/pluginutils.cjs.js",
-  "jsnext:main": "dist/pluginutils.es6.js",
+  "module": "dist/pluginutils.es.js",
+  "jsnext:main": "dist/pluginutils.es.js",
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "eslint": "^2.13.1",
     "mocha": "^2.5.3",
@@ -12,7 +16,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "build": "rollup -c -f cjs -o dist/pluginutils.cjs.js && rollup -c -f es6 -o dist/pluginutils.es6.js",
+    "build": "rollup -c",
     "pretest": "npm run build",
     "prepublish": "npm test"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,19 @@
+var pkg = require('./package.json');
 import buble from 'rollup-plugin-buble';
 
 export default {
 	entry: 'src/index.js',
 	plugins: [ buble() ],
-	external: [ 'path', 'minimatch' ]
+	external: [ 'path', 'minimatch' ],
+
+	targets: [
+		{
+				format: 'cjs',
+				dest: pkg['main']
+		},
+		{
+				format: 'es',
+				dest: pkg['module']
+		}
+	]
 };

--- a/src/utils/ensureArray.js
+++ b/src/utils/ensureArray.js
@@ -1,5 +1,1 @@
-export default function ensureArray ( thing ) {
-	if ( Array.isArray( thing ) ) return thing;
-	if ( thing == undefined ) return [];
-	return [ thing ];
-}
+export default ( thing ) => [...thing || []]


### PR DESCRIPTION
[🔧 Chore] Refactor ensureArray
  _(see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator)_
  √ Use Declarative Spread Operator `[...n]` instead of imperative type checking

[🔧 Chore] Use `es` formatter and remove deprecated `es6` from build process
  🔗  References #12