### PR TITLE
[:wrench: Chore] Use `es` formatter in build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "description": "Functionality commonly needed by Rollup plugins",
   "version": "1.5.2",
   "main": "dist/pluginutils.cjs.js",
-  "jsnext:main": "dist/pluginutils.es6.js",
+  "module": "dist/pluginutils.es.js",
+  "jsnext:main": "dist/pluginutils.es.js",
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "eslint": "^2.13.1",
     "mocha": "^2.5.3",
@@ -12,7 +16,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "build": "rollup -c -f cjs -o dist/pluginutils.cjs.js && rollup -c -f es6 -o dist/pluginutils.es6.js",
+    "build": "rollup -c",
     "pretest": "npm run build",
     "prepublish": "npm test"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,19 @@
+var pkg = require('./package.json');
 import buble from 'rollup-plugin-buble';
 
 export default {
 	entry: 'src/index.js',
 	plugins: [ buble() ],
-	external: [ 'path', 'minimatch' ]
+	external: [ 'path', 'minimatch' ],
+
+	targets: [
+		{
+			format: 'cjs',
+			dest: pkg['main']
+		},
+		{
+			format: 'es',
+			dest: pkg['module']
+		}
+	]
 };


### PR DESCRIPTION
  References #12

  :eyeglasses: :link: https://github.com/jsforum/jsforum/issues/5
  :eyeglasses: :link: https://github.com/rollup/rollup/wiki/jsnext:main
  :eyeglasses: :link: https://github.com/rollup/rollup/commit/b1e6823f08a9becb6dce019f82dba53278cd141f

[:wrench: Chore] Use `module` definition from package.json
[:wrench: Chore] Use `targets` definition from rollup.config.js