### PR TITLE
Make include/exclude patterns a little more robust and easier to work…

### DIFF
--- a/src/createFilter.js
+++ b/src/createFilter.js
@@ -13,16 +13,20 @@ export default function createFilter ( include, exclude ) {
 		if ( /\0/.test( id ) ) return false;
 
 		id = id.split( sep ).join( '/' );
+		
+		let keep = undefined;
 
 		for ( let i = 0; i < exclude.length; ++i ) {
 			const matcher = exclude[i];
-			if ( matcher.test( id ) ) return false;
+			if ( matcher.test( id ) ) keep = false;
 		}
 
 		for ( let i = 0; i < include.length; ++i ) {
 			const matcher = include[i];
-			if ( matcher.test( id ) ) return true;
+			if ( matcher.test( id ) ) keep = true;
 		}
+		
+		if ( keep !== undefined ) return keep
 
 		return !include.length;
 	};


### PR DESCRIPTION
… with.

This makes it possible to do the following:

```js
        babel({
            exclude: [ 'node_modules/**' ], // exclude everything in `node_modules`...
            include: [
                'src/**',
                'node_modules/@awaitbox/**' // ... except for stuff in node_modules/@awaitbox
            ],
            // ...
        }),
```

but currently, that doesn't work. We need an easy way to specify "exclude all of these... except for this and this".