### PR TITLE
fix(scopes): Support Function and Class Declarations without id

### DIFF
--- a/src/attachScopes.js
+++ b/src/attachScopes.js
@@ -61,7 +61,7 @@ class Scope {
 			// it's a `var` or function node, and this
 			// is a block scope, so we need to go up
 			this.parent.addDeclaration( node, isBlockDeclaration, isVar );
-		} else {
+		} else if ( node.id ) {
 			extractNames( node.id ).forEach( name => {
 				this.declarations[ name ] = true;
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,41 @@ describe( 'rollup-pluginutils', function () {
 			assert.ok( scope.contains( 'bar' ) );
 		});
 
+		it( 'supports FunctionDeclarations without id', function () {
+			var ast = {
+				"type": "Program",
+				"start": 0,
+				"end": 33,
+				"body": [
+				    {
+						"type": "ExportDefaultDeclaration",
+						"start": 0,
+						"end": 32,
+						"declaration": {
+							"type": "FunctionDeclaration",
+							"start": 15,
+							"end": 32,
+							"id": null,
+							"generator": false,
+							"expression": false,
+							"async": false,
+							"params": [],
+							"body": {
+								"type": "BlockStatement",
+								"start": 26,
+								"end": 32,
+								"body": []
+					  		}
+						}
+				  	}
+				],
+				"sourceType": "module"
+			  };
+
+			var scope = attachScopes( ast, 'scope' );
+			// does not throw
+		});
+
 		// TODO more tests
 	});
 


### PR DESCRIPTION
Declarations without id are used in combination with default exports

```js
export default function () {};
```

http://astexplorer.net/#/gist/cf7df7dd64907912d4c0b0c270c4d42c/39593db1b7ae5b05649f7d524e78f7439359602c

Without the fix I receive:

```
TypeError: Cannot read property 'type' of null
    at extractNames (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/dist/pluginutils.cjs.js:52:20)
    at Scope.addDeclaration (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/dist/pluginutils.cjs.js:86:3)
    at Object.enter (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/dist/pluginutils.cjs.js:108:11)
    at visit (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/node_modules/estree-walker/dist/estree-walker.umd.js:32:9)
    at visit (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/node_modules/estree-walker/dist/estree-walker.umd.js:51:4)
    at visit (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/node_modules/estree-walker/dist/estree-walker.umd.js:46:5)
    at Object.walk (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/node_modules/estree-walker/dist/estree-walker.umd.js:11:2)
    at Object.attachScopes (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-pluginutils/dist/pluginutils.cjs.js:103:15)
    at inject (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-plugin-node-globals/dist/rollup-plugin-node-globals.cjs.js:83:33)
    at Object.transform (/Users/danieltschinder/Documents/Github/babel/node_modules/rollup-plugin-node-globals/dist/rollup-plugin-node-globals.cjs.js:254:17)

```

//cc @Rich-Harris, @rollup :)