### PR TITLE
Support a namedExports false option for dataToEsm

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ const esModuleSource = dataToEsm({
   compact: false,
   indent: '\t',
   preferConst: false,
-  objectShorthand: false
+  objectShorthand: false,
+  namedExports: true
 });
 /*
 Outputs the string ES module source:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-pluginutils",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rollup-pluginutils",
   "description": "Functionality commonly needed by Rollup plugins",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/pluginutils.cjs.js",
   "module": "dist/pluginutils.es.js",
   "jsnext:main": "dist/pluginutils.es.js",

--- a/src/dataToEsm.js
+++ b/src/dataToEsm.js
@@ -47,7 +47,7 @@ export default function dataToNamedExports (data, options = {}) {
 	const n = options.compact ? '' : '\n';
 	const declarationType = options.preferConst ? 'const' : 'var';
 	
-	if (options.namedExports === false)
+	if (options.namedExports === false || typeof data !== 'object' || Array.isArray(data))
 		return `export default${ _ }${ serialize( data, options.compact ? null : t, '' ) };`;
 
 	let namedExportCode = '';

--- a/src/dataToEsm.js
+++ b/src/dataToEsm.js
@@ -47,7 +47,7 @@ export default function dataToNamedExports (data, options = {}) {
 	const n = options.compact ? '' : '\n';
 	const declarationType = options.preferConst ? 'const' : 'var';
 	
-	if (options.namedExports === false || typeof data !== 'object' || Array.isArray(data))
+	if (options.namedExports === false || typeof data !== 'object' || Array.isArray(data) || data === null)
 		return `export default${ _ }${ serialize( data, options.compact ? null : t, '' ) };`;
 
 	let namedExportCode = '';

--- a/src/dataToEsm.js
+++ b/src/dataToEsm.js
@@ -46,6 +46,9 @@ export default function dataToNamedExports (data, options = {}) {
 	const _ = options.compact ? '' : ' ';
 	const n = options.compact ? '' : '\n';
 	const declarationType = options.preferConst ? 'const' : 'var';
+	
+	if (options.namedExports === false)
+		return `export default${ _ }${ serialize( data, options.compact ? null : t, '' ) };`;
 
 	let namedExportCode = '';
 	const defaultExportRows = [];

--- a/test/test.js
+++ b/test/test.js
@@ -512,5 +512,10 @@ describe( 'rollup-pluginutils', function () {
 		it ( 'supports null serialize', function () {
 			assert.equal( dataToEsm( { null: null } ), 'export default {\n\t"null": null\n};\n' );
 		});
+
+		it ( 'supports default only', function () {
+			var arr = ['a', 'b'];
+			assert.equal( dataToEsm( { arr: arr }, { namedExports: false } ), 'export default {\n\tarr: [\n\t\t"a",\n\t\t"b"\n\t]\n};' );
+		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -517,5 +517,10 @@ describe( 'rollup-pluginutils', function () {
 			var arr = ['a', 'b'];
 			assert.equal( dataToEsm( { arr: arr }, { namedExports: false } ), 'export default {\n\tarr: [\n\t\t"a",\n\t\t"b"\n\t]\n};' );
 		});
+
+		it ( 'default only for non-objects', function () {
+			var arr = ['a', 'b'];
+			assert.equal( dataToEsm( arr ), 'export default [\n\t"a",\n\t"b"\n];' );
+		});
 	});
 });


### PR DESCRIPTION
This is useful for having a flag to entirely enable/disable named exports from data imports (currently named exports should be disabled for strict NodeJS compatibility with the work-in-progress implementation).