### PR TITLE
Support null params

### DIFF
--- a/src/attachScopes.js
+++ b/src/attachScopes.js
@@ -57,9 +57,10 @@ class Scope {
 
 		if ( options.params ) {
 			options.params.forEach( param => {
-				extractNames( param ).forEach( name => {
-					this.declarations[ name ] = true;
-				});
+				if (param)
+					extractNames( param ).forEach( name => {
+						this.declarations[ name ] = true;
+					});
 			});
 		}
 	}


### PR DESCRIPTION
This handles supporting `null` as a param in extractNames.