### PR TITLE
Generalize dataToEsm type and test additional primitive data types

### DIFF
--- a/src/dataToEsm.ts
+++ b/src/dataToEsm.ts
@@ -48,10 +48,7 @@ export interface Options {
 }
 
 // convert data object into separate named exports (and default)
-export default function dataToNamedExports<T extends { [key: string]: any }>(
-	data: T | Array<T>,
-	options: Options = {}
-): string {
+export default function dataToNamedExports(data: any, options: Options = {}): string {
 	const t = options.compact ? '' : 'indent' in options ? options.indent : '\t';
 	const _ = options.compact ? '' : ' ';
 	const n = options.compact ? '' : '\n';

--- a/test/dataToEsm.test.ts
+++ b/test/dataToEsm.test.ts
@@ -50,7 +50,7 @@ describe('dataToEsm', function() {
 		);
 	});
 
-	it('supports null serialize', function() {
+	it('serializes null', function() {
 		expect(dataToEsm({ null: null })).toEqual('export default {\n\t"null": null\n};\n');
 	});
 
@@ -61,8 +61,16 @@ describe('dataToEsm', function() {
 		);
 	});
 
-	it('default only for non-objects', function() {
+	it('exports default only for arrays', function() {
 		const arr = ['a', 'b'];
 		expect(dataToEsm(arr)).toEqual('export default [\n\t"a",\n\t"b"\n];');
+	});
+
+	it('exports default only for null', function() {
+		expect(dataToEsm(null)).toEqual('export default null;');
+	});
+
+	it('exports default only for primitive values', function() {
+		expect(dataToEsm('some string')).toEqual('export default "some string";');
 	});
 });


### PR DESCRIPTION
This does not contain any functional change but changes the input type of `dataToEsm` to `any` and adds additional tests that `null` and primitive values are handled correctly.