### PR TITLE
Sanitize special characters in the current working dir and resolution base dir

### DIFF
--- a/src/createFilter.ts
+++ b/src/createFilter.ts
@@ -3,11 +3,19 @@ import { resolve, sep } from 'path';
 import { CreateFilter } from './pluginutils';
 import ensureArray from './utils/ensureArray';
 
+function sanitizeResolutionBase(resolutionBase: string): string {
+	return resolutionBase.replace(/[()]/g, '\\$&');
+}
+
 function getMatcherString(id: string, resolutionBase: string | false | null | undefined) {
-	if (resolutionBase === false) {
-		return id;
-	}
-	return resolve(...(typeof resolutionBase === 'string' ? [resolutionBase, id] : [id]));
+	return resolutionBase === false
+		? id
+		: resolve(
+				sanitizeResolutionBase(
+					typeof resolutionBase === 'string' ? resolve(resolutionBase) : process.cwd()
+				),
+				id
+		  );
 }
 
 const createFilter: CreateFilter = function createFilter(include?, exclude?, options?) {

--- a/test/createFilter.test.ts
+++ b/test/createFilter.test.ts
@@ -105,4 +105,25 @@ describe('createFilter', function() {
 		expect(filter(path.resolve('.a'))).toBeTruthy();
 		expect(filter(path.resolve('.x/a'))).toBeTruthy();
 	});
+
+	it('escapes special characters in the base dir', () => {
+		const filter = createFilter(['a*'], null, { resolve: 'a()' });
+		expect(filter(path.resolve('a()/ab'))).toBeTruthy();
+	});
+
+	it('escapes special characters in the current working dir', () => {
+		const currentDir = process.cwd();
+		process.chdir(path.resolve(__dirname, 'special (characters)'));
+		const filter = createFilter(['a*']);
+		expect(filter(path.resolve('ab'))).toBeTruthy();
+		process.chdir(currentDir);
+	});
+
+	it('escapes special characters in both the base dir and the current working dir', () => {
+		const currentDir = process.cwd();
+		process.chdir(path.resolve(__dirname, 'special (characters)'));
+		const filter = createFilter(['a*'], null, { resolve: 'a()' });
+		expect(filter(path.resolve('a()/ab'))).toBeTruthy();
+		process.chdir(currentDir);
+	});
 });


### PR DESCRIPTION
For the moment, this will automatically escape opening and closing parantheses in the current working directory or the `resolve` parameter so that they are not interpreted as minimatch patterns.