### PR TITLE
Fix optional catch binding

### DIFF
--- a/src/attachScopes.ts
+++ b/src/attachScopes.ts
@@ -100,7 +100,7 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
 			if (node.type === 'CatchClause') {
 				newScope = new Scope({
 					parent: scope,
-					params: node.param ? [node.param] : undefined,
+					params: node.param ? [node.param] : [],
 					block: true
 				});
 			}

--- a/src/attachScopes.ts
+++ b/src/attachScopes.ts
@@ -100,7 +100,7 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
 			if (node.type === 'CatchClause') {
 				newScope = new Scope({
 					parent: scope,
-					params: [node.param],
+					params: node.param ? [node.param] : undefined,
 					block: true
 				});
 			}

--- a/test/attachScopes.test.ts
+++ b/test/attachScopes.test.ts
@@ -586,4 +586,42 @@ describe('attachScopes', function() {
 			attachScopes(ast, 'scope');
 		}).not.toThrow();
 	});
+
+	it('supports catch without a parameter', function() {
+		const ast = {
+			"type": "Program",
+			"start": 0,
+			"end": 23,
+			"body": [
+			  {
+				"type": "TryStatement",
+				"start": 0,
+				"end": 23,
+				"block": {
+				  "type": "BlockStatement",
+				  "start": 4,
+				  "end": 10,
+				  "body": []
+				},
+				"handler": {
+				  "type": "CatchClause",
+				  "start": 11,
+				  "end": 23,
+				  "param": null,
+				  "body": {
+					"type": "BlockStatement",
+					"start": 17,
+					"end": 23,
+					"body": []
+				  }
+				},
+				"finalizer": null
+			  }
+			],
+			"sourceType": "script"
+		  };
+		expect(() => {
+			attachScopes(ast, 'scope');
+		}).not.toThrow();
+	});
 });


### PR DESCRIPTION
This fixes the scenario where the catch clause does not have a parameter defined.

For example:

```js
try {
  console.log('foo')
} catch {
  console.log('bar')
}
```

This feature moved to stage 4 last year and is supported since Node 10 and Chrome 66.